### PR TITLE
Remove semi-colon parsed from model column type

### DIFF
--- a/src/autoswagger.ts
+++ b/src/autoswagger.ts
@@ -1178,10 +1178,10 @@ export class AutoSwagger {
       if (!line.startsWith("public ") && !line.startsWith("public get")) return;
       if (line.includes("(") && !line.startsWith("public get")) return;
       let s = line.split("public ");
-      let s2 = s[1].split(":");
+      let s2 = s[1].replace(/;/g, '').split(":");
       if (line.startsWith("public get")) {
         s = line.split("public get");
-        let s2 = s[1].split(":");
+        let s2 = s[1].replace(/;/g, '').split(":");
       }
 
       let field = s2[0];


### PR DESCRIPTION
If the model file uses semi-colons it would result in types like `DateTime;` instead of `DateTime`.

Removing the semi-colon fixes the issue.

Fixes #11