### PR TITLE
fix: error with anonymous functions in route def

### DIFF
--- a/src/autoswagger.ts
+++ b/src/autoswagger.ts
@@ -212,7 +212,7 @@ export class AutoSwagger {
       let action = "";
       let customAnnotations;
       if (route.meta.resolvedHandler !== null) {
-        if (typeof route.meta.resolvedHandler.namespace !== "undefined") {
+        if (typeof route.meta.resolvedHandler.namespace !== "undefined" && route.meta.resolvedHandler.method !== 'handle') {
           sourceFile = route.meta.resolvedHandler.namespace;
 
           action = route.meta.resolvedHandler.method;


### PR DESCRIPTION
Routes definitions containing anonymous functions instead of a reference to a Controller make AutoSwagger.generate method fails with : Error: ENOENT: no such file or directory, open 'app/Controllers/Http/.ts' Checking route.meta....method name allows to exclude those routes.