### PR TITLE
feat: define requestBody in json string

### DIFF
--- a/src/autoswagger.ts
+++ b/src/autoswagger.ts
@@ -759,17 +759,23 @@ export class AutoSwagger {
     if (json !== "") {
       try {
         let j = JSON.parse("{" + json + "}");
-        j = this.jsonToRef(j);
-        requestBody = {
-          content: {
-            "application/json": {
-              schema: {
-                type: "object",
-              },
-              example: j,
-            },
-          },
-        };
+	if( j.hasOwnProperty('content') ){
+		//Maybe user tries to define is own requestbody schema, for example to handle multipart/form-data 
+		requestBody = j;
+	}
+	else{
+        	j = this.jsonToRef(j);
+        	requestBody = {
+		  content: {
+		    "application/json": {
+		      schema: {
+			type: "object",
+		      },
+		      example: j,
+		    },
+		  },
+		};
+	}
       } catch {
         console.error("Invalid JSON for " + line);
       }


### PR DESCRIPTION
A short workaround to allow user to define request body via **@requestBody** _desc_ in JSON format. It permits to specify complex request body like required by OAS 3.X. For example, to take over multipart/form-data definition. 

See https://swagger.io/docs/specification/describing-request-body/file-upload/