### PR TITLE
feat: add formData request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ A summary of what the action does
 **@description** (only one)
 A detailed description of what the action does.
 
+**@operationId** (only one)
+An optional unique string used to identify an operation. If provided, these IDs must be unique among all operations described in your API..
+
 **@responseBody** (multiple)
 
 Format: `<status> - <return> - <description>`
@@ -206,6 +209,7 @@ export default {
 export default class SomeController {
   /**
    * @index
+   * @operationId getProducts
    * @description Returns array of producs and it's relations
    * @responseBody 200 - <Product[]>.with(relations)
    * @paramUse(sortable, filterable)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ Format: `<body>`
 
 `<body>` can be either a `<Schema>`, `<Schema[]>`or a custom JSON `{}`
 
+**@requestFormDataBody** (only one)
+A definition of the expected requestBody that will be sent with formData format.
+
+Format: `{}`
+
+This format should be a valid openapi 3.x json.
+
 ---
 
 # **Examples**
@@ -133,15 +140,17 @@ Format: `<body>`
 
 @responseBody <status> - <Model> // returns model specification
 
-  @responseBody <status> - <Model[]> // returns model-array specification
+@responseBody <status> - <Model[]> // returns model-array specification
 
-    @responseBody <status> - <Model>.with(relations, property1, property2.relations, property3.subproperty.relations) // returns a model and a defined relation
+@responseBody <status> - <Model>.with(relations, property1, property2.relations, property3.subproperty.relations) // returns a model and a defined relation
 
-      @responseBody <status> - <Model[]>.with(relations).exclude(property1, property2, property3.subproperty) // returns model specification
+@responseBody <status> - <Model[]>.with(relations).exclude(property1, property2, property3.subproperty) // returns model specification
 
-        @responseBody <status> - <Model[]>.append("some":"valid json") // append additional properties to a Model
-          @responseBody <status> - <Model>.only(property1, property2) // pick only specific properties
-            @responseBody <status> - {"foo": "bar"} //returns custom json
+@responseBody <status> - <Model[]>.append("some":"valid json") // append additional properties to a Model
+
+@responseBody <status> - <Model>.only(property1, property2) // pick only specific properties
+
+@responseBody <status> - {"foo": "bar"} //returns custom json
 ```
 
 ## `@requestBody` examples
@@ -152,6 +161,13 @@ Format: `<body>`
 @requestBody <Model>.with(relations) // Expects model and its relations
 @requestBody <Model[]>.append("some":"valid json") // append additional properties to a Model
 @requestBody {"foo": "bar"} // Expects a specific JSON
+```
+
+## `@requestFormDataBody` examples
+
+```js
+// basicaly same as @response, just without a status
+@requestFormDataBody {"name":{"type":"string"},"picture":{"type":"string","format":"binary"}} // Expects a valid OpenAPI 3.x JSON
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "typescript-parser": "^2.6.1"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.202",
     "@types/node": "^20.10.4"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,11 +34,18 @@ dependencies:
     version: 2.6.1
 
 devDependencies:
+  '@types/lodash':
+    specifier: ^4.14.202
+    version: 4.14.202
   '@types/node':
     specifier: ^20.10.4
     version: 20.10.4
 
 packages:
+
+  /@types/lodash@4.14.202:
+    resolution: {integrity: sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==}
+    dev: true
 
   /@types/node@20.10.4:
     resolution: {integrity: sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==}

--- a/src/autoswagger.ts
+++ b/src/autoswagger.ts
@@ -55,6 +55,26 @@ interface AdonisRoutes {
   root: AdonisRoute[];
 }
 
+/**
+ * Helpers
+ */
+
+function formatOperationId(inputString: string): string {
+  // Remove non-alphanumeric characters and split the string into words
+  const cleanedWords = inputString.replace(/[^a-zA-Z0-9]/g, " ").split(" ");
+
+  // Pascal casing words
+  const pascalCasedWords = cleanedWords.map((word) =>
+    startCase(camelCase(word))
+  );
+
+  // Generate operationId by joining every parts
+  const operationId = pascalCasedWords.join();
+
+  // CamelCase the operationId
+  return camelCase(operationId);
+}
+
 export class AutoSwagger {
   private parsedFiles: string[] = [];
   private options: options;
@@ -361,6 +381,11 @@ export class AutoSwagger {
               summary = "Delete " + tags[0].toLowerCase();
               break;
           }
+        }
+
+        // If not defined by an annotation, use the combination of "controllerNameMethodName"
+        if (action !== "" && isUndefined(operationId) && route.handler) {
+          operationId = formatOperationId(route.handler);
         }
 
         let m = {

--- a/src/autoswagger.ts
+++ b/src/autoswagger.ts
@@ -4,10 +4,12 @@ import path from "path";
 import util from "util";
 import extract from "extract-comments";
 import HTTPStatusCode from "http-status-code";
-import _ from "lodash";
-import { snakeCase } from "change-case";
+import { camelCase, isEmpty, isUndefined, snakeCase, startCase } from "lodash";
 import { existsSync } from "fs";
 
+/**
+ * Autoswagger interfaces
+ */
 interface options {
   title: string;
   ignore: string[];
@@ -24,6 +26,35 @@ interface common {
   parameters: any;
 }
 
+/**
+ * Adonis routes
+ */
+interface AdonisRouteMeta {
+  resolvedHandler: {
+    type: string;
+    namespace?: string;
+    method?: string;
+  };
+  resolvedMiddleware: Array<{
+    type: string;
+    args?: any[];
+  }>;
+}
+
+interface AdonisRoute {
+  methods: string[];
+  pattern: string;
+  meta: AdonisRouteMeta;
+  middleware: string[];
+  name?: string;
+  params: string[];
+  handler?: string;
+}
+
+interface AdonisRoutes {
+  root: AdonisRoute[];
+}
+
 export class AutoSwagger {
   private parsedFiles: string[] = [];
   private options: options;
@@ -37,12 +68,12 @@ export class AutoSwagger {
     "boolean",
     "any",
   ]
-      .map((type) => [type, type + "[]"])
-      .flat();
+    .map((type) => [type, type + "[]"])
+    .flat();
 
   ui(url: string) {
     return (
-        `<!DOCTYPE html>
+      `<!DOCTYPE html>
 		<html lang="en">
 		<head>
 				<meta charset="UTF-8">
@@ -59,8 +90,8 @@ export class AutoSwagger {
 						window.onload = function() {
 							SwaggerUIBundle({
 								url: "` +
-        url +
-        `",
+      url +
+      `",
 								dom_id: '#swagger-ui',
 								presets: [
 									SwaggerUIBundle.presets.apis,
@@ -77,7 +108,7 @@ export class AutoSwagger {
 
   rapidoc(url: string, style = "view") {
     return (
-        `
+      `
     <!doctype html> <!-- Important: must specify -->
     <html>
       <head>
@@ -88,8 +119,8 @@ export class AutoSwagger {
       <body>
         <rapi-doc
           spec-url = "` +
-        url +
-        `"
+      url +
+      `"
       theme = "dark"
       bg-color = "#24283b"
       header-color = "#1a1b26"
@@ -101,8 +132,8 @@ export class AutoSwagger {
       heading-text = "Documentation"
       sort-tags = "true"
       render-style = "` +
-        style +
-        `"
+      style +
+      `"
       default-schema-tab = "example"
       show-components = "true"
       allow-spec-url-load = "false"
@@ -132,14 +163,14 @@ export class AutoSwagger {
     return data;
   }
 
-  async docs(routes, options: options) {
+  async docs(routes: AdonisRoutes, options: options) {
     if (process.env.NODE_ENV === "production") {
       return this.readFile(options.path);
     }
     return this.generate(routes, options);
   }
 
-  async generate(routes, options: options) {
+  async generate(adonisRoutes: AdonisRoutes, options: options) {
     this.options = {
       ...{
         snakeCase: true,
@@ -147,7 +178,7 @@ export class AutoSwagger {
       },
       ...options,
     };
-    routes = routes.root;
+    const routes = adonisRoutes.root;
     this.options.path = path.join(this.options.path + "/../app");
     this.schemas = await this.getSchemas();
 
@@ -217,16 +248,16 @@ export class AutoSwagger {
       let customAnnotations;
       if (route.meta.resolvedHandler !== null) {
         if (
-            typeof route.meta.resolvedHandler.namespace !== "undefined" &&
-            route.meta.resolvedHandler.method !== "handle"
+          typeof route.meta.resolvedHandler.namespace !== "undefined" &&
+          route.meta.resolvedHandler.method !== "handle"
         ) {
           sourceFile = route.meta.resolvedHandler.namespace;
 
           action = route.meta.resolvedHandler.method;
           if (sourceFile !== "" && action !== "") {
             customAnnotations = await this.getCustomAnnotations(
-                sourceFile,
-                action
+              sourceFile,
+              action
             );
           }
         }
@@ -248,15 +279,15 @@ export class AutoSwagger {
         if (method === "HEAD") return;
 
         if (
-            route.methods.includes("PUT") &&
-            route.methods.includes("PATCH") &&
-            method !== this.options.preferredPutPatch
+          route.methods.includes("PUT") &&
+          route.methods.includes("PATCH") &&
+          method !== this.options.preferredPutPatch
         )
           return;
 
         let description = "";
         let summary = "";
-        let operationId;
+        let operationId: string;
 
         if (security.length > 0) {
           responses["401"] = {
@@ -285,7 +316,7 @@ export class AutoSwagger {
         }
         parameters = this.mergeParams(parameters, actionParams);
 
-        if (_.isEmpty(responses)) {
+        if (isEmpty(responses)) {
           responses[responseCodes[method]] = {
             description: HTTPStatusCode.getMessage(responseCodes[method]),
             content: {
@@ -294,8 +325,8 @@ export class AutoSwagger {
           };
         } else {
           if (
-              typeof responses[responseCodes[method]] !== "undefined" &&
-              typeof responses[responseCodes[method]]["summary"] !== "undefined"
+            typeof responses[responseCodes[method]] !== "undefined" &&
+            typeof responses[responseCodes[method]]["summary"] !== "undefined"
           ) {
             if (summary === "") {
               summary = responses[responseCodes[method]]["summary"];
@@ -303,8 +334,8 @@ export class AutoSwagger {
             delete responses[responseCodes[method]]["summary"];
           }
           if (
-              typeof responses[responseCodes[method]] !== "undefined" &&
-              typeof responses[responseCodes[method]]["description"] !==
+            typeof responses[responseCodes[method]] !== "undefined" &&
+            typeof responses[responseCodes[method]]["description"] !==
               "undefined"
           ) {
             description = responses[responseCodes[method]]["description"];
@@ -334,14 +365,14 @@ export class AutoSwagger {
 
         let m = {
           summary:
-              sourceFile === "" && action == ""
-                  ? summary + " (route.ts)"
-                  : summary +
-                  " (" +
-                  sourceFile.replace("App/Controllers/Http/", "") +
-                  "::" +
-                  action +
-                  ")",
+            sourceFile === "" && action == ""
+              ? summary + " (route.ts)"
+              : summary +
+                " (" +
+                sourceFile.replace("App/Controllers/Http/", "") +
+                "::" +
+                action +
+                ")",
           description: description,
           operationId: operationId,
           parameters: parameters,
@@ -428,7 +459,7 @@ export class AutoSwagger {
       if (line.startsWith("@description")) {
         description = line.replace("@description ", "");
       }
-      
+
       if (line.startsWith("@operationId")) {
         operationId = line.replace("@operationId ", "");
       }
@@ -562,12 +593,12 @@ export class AutoSwagger {
     return { [param]: p };
   }
 
-  private parseResponseHeader(line) {
+  private parseResponseHeader(responseLine: string) {
     let description = "";
     let example: any = "";
     let type = "string";
     let enums = [];
-    line = line.replace("@responseHeader ", "");
+    const line = responseLine.replace("@responseHeader ", "");
     let [status, name, desc, meta] = line.split(" - ");
 
     if (typeof status === "undefined" || typeof name === "undefined") {
@@ -634,9 +665,9 @@ export class AutoSwagger {
     };
   }
 
-  private parseResponse(line) {
+  private parseResponse(responseLine: string) {
     let responses = {};
-    line = line.replace("@responseBody ", "");
+    const line = responseLine.replace("@responseBody ", "");
     let [status, res] = line.split(" - ");
     let sum = "";
     if (typeof status === "undefined") return;
@@ -687,8 +718,8 @@ export class AutoSwagger {
               },
               example: [
                 Object.assign(
-                    this.getSchemaExampleBasedOnAnnotation(ref, inc, exc, only),
-                    app
+                  this.getSchemaExampleBasedOnAnnotation(ref, inc, exc, only),
+                  app
                 ),
               ],
             },
@@ -698,8 +729,8 @@ export class AutoSwagger {
             "application/json": {
               schema: { $ref: "#/components/schemas/" + ref },
               example: Object.assign(
-                  this.getSchemaExampleBasedOnAnnotation(ref, inc, exc, only),
-                  app
+                this.getSchemaExampleBasedOnAnnotation(ref, inc, exc, only),
+                app
               ),
             },
           };
@@ -749,14 +780,14 @@ export class AutoSwagger {
             ref = ref.replace("[]", "");
             v = [
               Object.assign(
-                  this.getSchemaExampleBasedOnAnnotation(ref, inc, exc, only),
-                  app
+                this.getSchemaExampleBasedOnAnnotation(ref, inc, exc, only),
+                app
               ),
             ].reduce((a) => a);
           } else {
             v = Object.assign(
-                this.getSchemaExampleBasedOnAnnotation(ref, inc, exc, only),
-                app
+              this.getSchemaExampleBasedOnAnnotation(ref, inc, exc, only),
+              app
             );
           }
         }
@@ -816,8 +847,8 @@ export class AutoSwagger {
               },
               example: [
                 Object.assign(
-                    this.getSchemaExampleBasedOnAnnotation(ref, inc, exc, only),
-                    app
+                  this.getSchemaExampleBasedOnAnnotation(ref, inc, exc, only),
+                  app
                 ),
               ],
             },
@@ -831,8 +862,8 @@ export class AutoSwagger {
                 $ref: "#/components/schemas/" + ref,
               },
               example: Object.assign(
-                  this.getSchemaExampleBasedOnAnnotation(ref, inc, exc, only),
-                  app
+                this.getSchemaExampleBasedOnAnnotation(ref, inc, exc, only),
+                app
               ),
             },
           },
@@ -842,7 +873,7 @@ export class AutoSwagger {
     return requestBody;
   }
 
-  private getBetweenBrackets(value, start) {
+  private getBetweenBrackets(value: string, start: string) {
     let match = value.match(new RegExp(start + "\\(([^()]*)\\)", "g"));
 
     if (match !== null) {
@@ -858,13 +889,13 @@ export class AutoSwagger {
   }
 
   private getSchemaExampleBasedOnAnnotation(
-      schema,
-      inc = "",
-      exc = "",
-      onl = "",
-      first = "",
-      parent = "",
-      level = 0
+    schema: string,
+    inc = "",
+    exc = "",
+    onl = "",
+    first = "",
+    parent = "",
+    level = 0
   ) {
     let props = {};
     if (!this.schemas[schema]) {
@@ -881,13 +912,13 @@ export class AutoSwagger {
 
     // skip nested if not requested
     if (
-        parent !== "" &&
-        schema !== "" &&
-        parent.includes(".") &&
-        this.schemas[schema].description === "Model" &&
-        !inc.includes(parent) &&
-        !inc.includes(parent + ".relations") &&
-        !inc.includes(first + ".relations")
+      parent !== "" &&
+      schema !== "" &&
+      parent.includes(".") &&
+      this.schemas[schema].description === "Model" &&
+      !inc.includes(parent) &&
+      !inc.includes(parent + ".relations") &&
+      !inc.includes(first + ".relations")
     ) {
       return null;
     }
@@ -898,22 +929,22 @@ export class AutoSwagger {
       if (exclude.includes(parent + "." + key)) continue;
 
       if (
-          key === "password" &&
-          !include.includes("password") &&
-          !only.includes("password")
+        key === "password" &&
+        !include.includes("password") &&
+        !only.includes("password")
       )
         continue;
       if (
-          key === "password_confirmation" &&
-          !include.includes("password_confirmation") &&
-          !only.includes("password_confirmation")
+        key === "password_confirmation" &&
+        !include.includes("password_confirmation") &&
+        !only.includes("password_confirmation")
       )
         continue;
       if (
-          (key === "created_at" ||
-              key === "updated_at" ||
-              key === "deleted_at") &&
-          exc.includes("timestamps")
+        (key === "created_at" ||
+          key === "updated_at" ||
+          key === "deleted_at") &&
+        exc.includes("timestamps")
       )
         continue;
 
@@ -927,8 +958,8 @@ export class AutoSwagger {
       }
 
       if (
-          typeof value["items"] !== "undefined" &&
-          typeof value["items"]["$ref"] !== "undefined"
+        typeof value["items"] !== "undefined" &&
+        typeof value["items"]["$ref"] !== "undefined"
       ) {
         rel = value["items"]["$ref"].replace("#/components/schemas/", "");
       }
@@ -941,19 +972,19 @@ export class AutoSwagger {
       if (rel !== "") {
         // skip related models of main schema
         if (
-            parent === "" &&
-            rel !== "" &&
-            typeof this.schemas[rel] !== "undefined" &&
-            this.schemas[rel].description === "Model" &&
-            !include.includes("relations") &&
-            !include.includes(key)
+          parent === "" &&
+          rel !== "" &&
+          typeof this.schemas[rel] !== "undefined" &&
+          this.schemas[rel].description === "Model" &&
+          !include.includes("relations") &&
+          !include.includes(key)
         ) {
           continue;
         }
 
         if (
-            typeof value["items"] !== "undefined" &&
-            typeof value["items"]["$ref"] !== "undefined"
+          typeof value["items"] !== "undefined" &&
+          typeof value["items"]["$ref"] !== "undefined"
         ) {
           rel = value["items"]["$ref"].replace("#/components/schemas/", "");
         }
@@ -964,13 +995,13 @@ export class AutoSwagger {
         let propdata: any = "";
         if (level <= 10) {
           propdata = this.getSchemaExampleBasedOnAnnotation(
-              rel,
-              inc,
-              exc,
-              onl,
-              parent,
-              parent === "" ? key : parent + "." + key,
-              level++
+            rel,
+            inc,
+            exc,
+            onl,
+            parent,
+            parent === "" ? key : parent + "." + key,
+            level++
           );
         }
 
@@ -990,18 +1021,19 @@ export class AutoSwagger {
   /*
     extract path-variables, tags and the uri-pattern
   */
-  private extractInfos(p) {
+  private extractInfos(p: string) {
     let parameters = {};
     let pattern = "";
     let tags = [];
     let required: boolean;
+
     const split = p.split("/");
     if (split.length > this.options.tagIndex) {
       tags = [split[this.options.tagIndex].toUpperCase()];
     }
     split.forEach((part) => {
       if (part.startsWith(":")) {
-        required = !part.endsWith('?');
+        required = !part.endsWith("?");
         const param = part.replace(":", "").replace("?", "");
         part = "{" + param + "}";
         parameters = {
@@ -1095,14 +1127,14 @@ export class AutoSwagger {
       if (line.startsWith("export") && !line.startsWith("export default"))
         return;
       if (
-          line.startsWith("//") ||
-          line.startsWith("/*") ||
-          line.startsWith("*")
+        line.startsWith("//") ||
+        line.startsWith("/*") ||
+        line.startsWith("*")
       )
         return;
       if (
-          line.startsWith("interface ") ||
-          line.startsWith("export default interface ")
+        line.startsWith("interface ") ||
+        line.startsWith("export default interface ")
       ) {
         props = {};
         name = line;
@@ -1195,15 +1227,15 @@ export class AutoSwagger {
       line = line.trim();
       // skip comments
       if (
-          line.includes("@swagger-softdelete") ||
-          line.includes("SoftDeletes")
+        line.includes("@swagger-softdelete") ||
+        line.includes("SoftDeletes")
       ) {
         softDelete = true;
       }
       if (
-          line.startsWith("//") ||
-          line.startsWith("/*") ||
-          line.startsWith("*")
+        line.startsWith("//") ||
+        line.startsWith("/*") ||
+        line.startsWith("*")
       )
         return;
       if (index > 0 && lines[index - 1].includes("serializeAs: null")) return;
@@ -1287,15 +1319,15 @@ export class AutoSwagger {
       let isArray = false;
 
       if (
-          line.includes("HasMany") ||
-          line.includes("ManyToMany") ||
-          line.includes("HasManyThrough") ||
-          type.includes("[]")
+        line.includes("HasMany") ||
+        line.includes("ManyToMany") ||
+        line.includes("HasManyThrough") ||
+        type.includes("[]")
       ) {
         isArray = true;
         if (
-            type.slice(type.length - 2, type.length) === "[]" &&
-            this.standardTypes.includes(type.toLowerCase())
+          type.slice(type.length - 2, type.length) === "[]" &&
+          this.standardTypes.includes(type.toLowerCase())
         ) {
           type = type.toLowerCase().split("[]")[0];
         }

--- a/src/autoswagger.ts
+++ b/src/autoswagger.ts
@@ -256,6 +256,7 @@ export class AutoSwagger {
 
         let description = "";
         let summary = "";
+        let operationId;
 
         if (security.length > 0) {
           responses["401"] = {
@@ -277,6 +278,7 @@ export class AutoSwagger {
         if (action !== "" && typeof customAnnotations[action] !== "undefined") {
           description = customAnnotations[action].description;
           summary = customAnnotations[action].summary;
+          operationId = customAnnotations[action].operationId;
           responses = { ...responses, ...customAnnotations[action].responses };
           requestBody = customAnnotations[action].requestBody;
           actionParams = customAnnotations[action].parameters;
@@ -341,6 +343,7 @@ export class AutoSwagger {
                   action +
                   ")",
           description: description,
+          operationId: operationId,
           parameters: parameters,
           tags: tags,
           responses: responses,
@@ -402,6 +405,7 @@ export class AutoSwagger {
     let summary = "";
     let upload = "";
     let description = "";
+    let operationId;
     let responses = {};
     let requestBody = {};
     requestBody = {
@@ -424,6 +428,11 @@ export class AutoSwagger {
       if (line.startsWith("@description")) {
         description = line.replace("@description ", "");
       }
+      
+      if (line.startsWith("@operationId")) {
+        operationId = line.replace("@operationId ", "");
+      }
+
       if (line.startsWith("@responseBody")) {
         responses = { ...responses, ...this.parseResponse(line) };
       }
@@ -458,6 +467,7 @@ export class AutoSwagger {
       requestBody: requestBody,
       parameters: parameters,
       summary: summary,
+      operationId: operationId,
     };
   }
 


### PR DESCRIPTION
To handle the formData request body, a new comment has been introduced: `@requestFormDataBody {]`

The JSON needs to be a valid OpenAPI 3.x one. Annotations will look like this:

```
/**
   * @updateCategory
   * @operationId updateCategory
   * @requestFormDataBody {"name":{"type":"string"},"illustration":{"type":"string","format":"binary"}}
   * @responseBody 200 - <RentalObjectCategory>
   */
```

This will allow having this in the swagger UI: 
![image](https://github.com/ad-on-is/adonis-autoswagger/assets/5345431/f82b7e0c-42f4-4edd-9f5c-5dfadcd4f859)

This should answer the issues filled here : https://github.com/ad-on-is/adonis-autoswagger/issues/17


