### PR TITLE
Add support for persistAuthorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ export default {
     parameters: {}, // OpenAPI conform parameters that are commonly used
     headers: {}, // OpenAPI conform headers that are commonly used
   },
-  persistAuthorization: true // persist authorization between reloads onthe swagger page
+  persistAuthorization: true // persist authorization between reloads on the swagger page
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Route.get("/swagger", async () => {
 
 // Renders Swagger-UI and passes YAML-output of /swagger
 Route.get("/docs", async () => {
-  return AutoSwagger.ui("/swagger");
+  return AutoSwagger.ui("/swagger", swagger);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ export default {
     parameters: {}, // OpenAPI conform parameters that are commonly used
     headers: {}, // OpenAPI conform headers that are commonly used
   },
+  persistAuthorization: true // persist authorization between reloads onthe swagger page
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc"
+    "build": "tsc",
+    "prepare": "npm run build"
   },
   "author": "Adis Durakovic <adis.durakovic@gmail.com>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adonis-autoswagger",
-  "version": "1.8.4",
+  "version": "1.9.0",
   "description": "Auto-Generate swagger docs for AdonisJS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/autoswagger.ts
+++ b/src/autoswagger.ts
@@ -17,6 +17,7 @@ interface options {
   snakeCase: boolean;
   common: common;
   preferredPutPatch?: string;
+  persistAuthorization?: boolean;
 }
 
 interface common {
@@ -40,7 +41,8 @@ export class AutoSwagger {
       .map((type) => [type, type + "[]"])
       .flat();
 
-  ui(url: string) {
+  ui(url: string, options?: options) {
+    const persistAuthString = options?.persistAuthorization ? 'persistAuthorization: true,' : '';
     return (
         `<!DOCTYPE html>
 		<html lang="en">
@@ -58,15 +60,14 @@ export class AutoSwagger {
 				<script>
 						window.onload = function() {
 							SwaggerUIBundle({
-								url: "` +
-        url +
-        `",
+								url: "` + url + `",
 								dom_id: '#swagger-ui',
 								presets: [
 									SwaggerUIBundle.presets.apis,
 									SwaggerUIStandalonePreset
 								],
-								layout: "BaseLayout"
+								layout: "BaseLayout",
+                ` + persistAuthString + `
 							})
 						}
 				</script>

--- a/src/autoswagger.ts
+++ b/src/autoswagger.ts
@@ -60,7 +60,7 @@ export class AutoSwagger {
 				<script>
 						window.onload = function() {
 							SwaggerUIBundle({
-								url: "` + url + `",
+								url: "${url}",
 								dom_id: '#swagger-ui',
 								presets: [
 									SwaggerUIBundle.presets.apis,

--- a/src/autoswagger.ts
+++ b/src/autoswagger.ts
@@ -67,7 +67,7 @@ export class AutoSwagger {
 									SwaggerUIStandalonePreset
 								],
 								layout: "BaseLayout",
-                ` + persistAuthString + `
+                ${persistAuthString}
 							})
 						}
 				</script>


### PR DESCRIPTION
SwaggerUI supports a parameter named `persistAuthorization` so that you're not logged out of the API on every reload.

https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#authorization

This adds optional support for that setting.