### PR TITLE
fix "declare" parser

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -476,14 +476,13 @@ export class ModelParser {
       if (
         !line.startsWith("public ") &&
         !line.startsWith("public get") &&
-        !line.startsWith("declare ")
+        !line.includes("declare ")
       )
         return;
-      if (line.includes("(") && !line.startsWith("public get")) return;
-
+      
       let s = [];
 
-      if (line.startsWith("declare ")) {
+      if (line.includes("declare ")) {
         s = line.split("declare ");
       }
       if (line.startsWith("public ")) {


### PR DESCRIPTION
made fix to be able to declare the column in the model also on the same row

Before:
@column() declare id: number
Doesn't work

Now:
@column() declare id: number

or

@column()
declare id: number

it works the same way