### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ router.get("/swagger", async () => {
 // Renders Swagger-UI and passes YAML-output of /swagger
 router.get("/docs", async () => {
   return AutoSwagger.default.ui("/swagger", swagger);
-  // return AutoSwagger.default.scalar("/swagger", swagger); to use Scalar instead
+  // return AutoSwagger.default.scalar("/swagger"); to use Scalar instead
   // return AutoSwagger.default.rapidoc("/swagger", swagger); to use RapiDoc instead
 });
 ```


### PR DESCRIPTION
Since scalar only accepts path, I updated the example to reflect that.
By the way, I'm not sure what are possible values for rapidoc second arg, which is documented as `style`. That might need to be fixed as well.