### PR TITLE
feat: update 'paginated' decorator to override default names

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ This format should be a valid openapi 3.x json.
 
 @responseBody <status> - <Model[]>.paginated() // helper function to return adonisJS conform structure like {"data": [], "meta": {}}
 
-@responseBody <status> - <Model[]>.as('contents').paginated() // returns a paginated model with a custom key for the data array
+@responseBody <status> - <Model[]>.paginated(dataName, metaName) // returns a paginated model with custom keys for the data array and meta object, use `.paginated(dataName)` or `.paginated(,metaName)` if you want to override only one. Don't forget the ',' for the second parameter.
 
 @responseBody <status> - <Model>.only(property1, property2) // pick only specific properties
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ This format should be a valid openapi 3.x json.
 
 @responseBody <status> - <Model[]>.paginated() // helper function to return adonisJS conform structure like {"data": [], "meta": {}}
 
+@responseBody <status> - <Model[]>.as('contents').paginated() // returns a paginated model with a custom key for the data array
+
 @responseBody <status> - <Model>.only(property1, property2) // pick only specific properties
 
 @requestBody <status> <myCustomValidator> // returns a validator object

--- a/src/example.ts
+++ b/src/example.ts
@@ -51,10 +51,12 @@ export default class ExampleGenerator {
     const append = getBetweenBrackets(line, "append");
     const only = getBetweenBrackets(line, "only");
     const paginated = getBetweenBrackets(line, "paginated");
+    const as = getBetweenBrackets(line, "as");
+
     let app = {};
     try {
       app = JSON.parse("{" + append + "}");
-    } catch {}
+    } catch { }
 
     const cleandRef = rawRef.replace("[]", "");
     let ex = Object.assign(
@@ -62,15 +64,23 @@ export default class ExampleGenerator {
       app
     );
 
+    let contentName = "data";
+    if (as) {
+      const asMatch = line.match(/\.as\('([^']+)'\)/);
+      if (asMatch) {
+        contentName = asMatch[1];
+      }
+    }
+
     const paginatedEx = {
-      data: [ex],
+      [contentName]: [ex],
       meta: this.getSchemaExampleBasedOnAnnotation("PaginationMeta"),
     };
 
     const paginatedSchema = {
       type: "object",
       properties: {
-        data: {
+        [contentName]: {
           type: "array",
           items: { $ref: "#/components/schemas/" + cleandRef },
         },


### PR DESCRIPTION
Hello everyone, 

I hope everyone is well. 

I had a specific need in my project, requested by the frontend team. 

This requirement was that with the 'pagination' part we could have a specific object name corresponding to the type of data that was returned. 

Simple with Adonis, but the swagger defaulted to 'data'. 

So I added a little decorator `as('')` which simply modifies this name. 

**Example:**

`* @responseBody 200 - <Media[]>.as('contents').paginated()`

Returns swagger 

![image](https://github.com/ad-on-is/adonis-autoswagger/assets/105598361/c3c4d9f6-1e52-4ce8-8721-5cafeddc9fe5)

If there's no 'as' or if you have 'as.('')', you'll go back to the default data. 

I wasn't very inspired for the name, but if I need to change it or if I've forgotten something, I can modify this.
