### PR TITLE
feat: double type interface

### DIFF
--- a/src/example.ts
+++ b/src/example.ts
@@ -211,7 +211,10 @@ export default class ExampleGenerator {
         example = value["items"]["example"];
       }
 
-      if (rel !== "") {
+
+      const isDoubleType = value["$ref"] && value["$ref"].includes('|');
+
+      if (rel !== "" && !isDoubleType) {
         // skip related models of main schema
         if (
           parent === "" &&

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -987,7 +987,11 @@ export class InterfaceParser {
     }
 
     if (example === null) {
-      example = this.exampleGenerator.exampleByType(type);
+      if (type.includes("|")) {
+        example = this.exampleGenerator.exampleByType(type.split("|")[0].trim());
+      } else {
+        example = this.exampleGenerator.exampleByType(type);
+      }
     }
 
     if (en !== "") {
@@ -995,7 +999,8 @@ export class InterfaceParser {
       example = enums[0];
     }
     let indicator = "type";
-    let notRequired = field.includes("?");
+
+    let notRequired = field.includes("?") || type.split("|").map(t => t.trim()).includes('null');
 
     prop["nullable"] = notRequired;
     if (type.toLowerCase() === "datetime") {


### PR DESCRIPTION
Good evening, 

I've made a modification to the way double types are handled, in particular with the `null`.

I have an interface with several `string | null` or `number | null` fields.

and the swagger handled example and schema by returning : 

```
field: {},
```

What's more, the schema didn't handle the nullable.

So I made the changes to default to the first type specified for the example, and to specify `nullable` correctly if one of the types is null. 

I don't know if this is the best way to do it, so I'll wait for your feedback!