### PR TITLE
feat: Add a way to declare enums in interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,18 @@ Automatically generates swagger schema-descriptions based on your models
 
 Instead of using `param: any` you can now use custom interfaces `param: UserDetails`. The interfaces files need to be located at `app/Interfaces/`
 
+#### Usage of enums
+
+Adding the @enum() at the end of the property will allow the correct values to be added to the specification.
+
+```ts
+export interface ICustomer {
+  email: string;
+  name: string;
+  gender: string; // @enum(male,female,genderless)
+}
+```
+
 ## Extend Models
 
 Add additional documentation to your Models properties.

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -270,7 +270,8 @@ export class CommentParser {
 
   private parseRequestFormDataBody(rawLine: string) {
     const line = rawLine.replace("@requestFormDataBody ", "");
-    let json = {}, required = [];
+    let json = {},
+      required = [];
     const isJson = isJSONString(line);
     if (!isJson) {
       // try to get json from reference
@@ -284,7 +285,8 @@ export class CommentParser {
       let props = [];
       const ref = this.exampleGenerator.schemas[cleandRef];
       const ks = [];
-      if (ref.required && Array.isArray(ref.required)) required.push(...ref.required)
+      if (ref.required && Array.isArray(ref.required))
+        required.push(...ref.required);
       Object.entries(ref.properties).map(([key, value]) => {
         if (typeof parsedRef[key] === "undefined") {
           return;
@@ -314,9 +316,9 @@ export class CommentParser {
       json = JSON.parse(line);
       for (let key in json) {
         if (json[key].required === "true") {
-          required.push(key)
+          required.push(key);
         }
-    }
+      }
     }
     // No need to try/catch this JSON.parse as we already did that in the isJSONString function
 
@@ -923,7 +925,7 @@ export class ValidatorParser {
                 : this.exampleGenerator.exampleByType("number"),
               ...meta,
             };
-      if(!p["isOptional"]) obj[p["fieldName"]]["required"] = true;
+      if (!p["isOptional"]) obj[p["fieldName"]]["required"] = true;
     }
     return obj;
   }
@@ -979,8 +981,13 @@ export class InterfaceParser {
       type = type.replace("[]", "");
       isArray = true;
     }
-    let prop: any = { type: type };
     let meta = "";
+    if (type.includes("@enum")) {
+      // Extract the enum values from the line
+      meta = type.substring(type.indexOf("@enum"));
+      type = "string";
+    }
+    let prop: any = { type: type };
     let en = getBetweenBrackets(meta, "enum");
     let example = getBetweenBrackets(meta, "example");
     let enums = [];
@@ -1016,6 +1023,9 @@ export class InterfaceParser {
 
       prop[indicator] = type;
       prop["example"] = example;
+      if (enums.length > 0) {
+        prop["enum"] = enums.map((e) => e.trim()); // Clean the enum by removing start and end spaces
+      }
       prop["nullable"] = notRequired;
     }
     if (isArray) {


### PR DESCRIPTION
I added a way to declare enums for a string property when used inside an interface.
This is not done the same way as other declarations, but it works with a minimal impact on the lib code and is not so much annoying I think for developers. 

A better way should probably be able to parse real typescript enums, but for the moment, it can be sufficient. 