### PR TITLE
Nullable value not supported in @responseBody return

### DIFF
--- a/src/example.ts
+++ b/src/example.ts
@@ -11,7 +11,7 @@ export default class ExampleGenerator {
     let out = {};
     let outArr = [];
     for (let [k, v] of Object.entries(json)) {
-      if (typeof v === "object") {
+      if (typeof v === "object" && v) {
         if (!Array.isArray(v)) {
           v = this.jsonToRef(v);
         }

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -389,7 +389,7 @@ export class CommentParser {
           const t = typeof json[key];
           const v = json[key];
           let value = v;
-          if (t === "object") {
+          if (t === "object" && json[key]) {
             value = this.jsonToObj(json[key]);
           }
           if (t === "string" && v.includes("<") && v.includes(">")) {


### PR DESCRIPTION
In the response body, I want to define the json below :
```
{
  "status": "success",
  "data": {
    "token": {
      "type": "auth_token",
      "expiresAt": "2024-09-24T15:55:33.055Z",
      "accessToken": "..."
    },
    "user": {
      "id": 1,
      "positionId": null,
      "courtId": null,
      "firstName": "John",
      "lastName": null,
      "phoneNumber": "+XXXXXXXXX",
      "email": "test@xyz.cm",
      "role": "root",
      "deletedAt": null,
      "createdAt": "2024-08-11T11:24:04.000+02:00",
      "updatedAt": "2024-08-11T11:24:04.000+02:00"
    }
  }
}
``` 
Using the syntax, in the GitHub documentation like that:
```
/**
   * @createToken
   * @requestBody  {"email": "admin@xyz.com", "password": "password"}
   * @responseBody 200 - {"status":"success","data":{"token":{"type":"auth_token","expiresAt":"2024-09-24T15:55:33.055Z","accessToken":"..."},"user":{"id":1,"positionId":null,"courtId":null,"firstName":"John","lastName":null,"phoneNumber":"+XXXXXXXXX","email":"test@xyz.cm","role":"root","deletedAt":null,"createdAt":"2024-08-11T11:24:04.000+02:00","updatedAt":"2024-08-11T11:24:04.000+02:00"}}}
   */
``` 
When generating the API Documentation, I get the error below :
![image](https://github.com/user-attachments/assets/d715693e-1f81-485b-8b77-bfb231758ffe)

**I'm going to associate this error with a pull request that you can merge with the master.**