### PR TITLE
[feature] Scalar Proxy URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ router.get("/swagger", async () => {
 // Renders Swagger-UI and passes YAML-output of /swagger
 router.get("/docs", async () => {
   return AutoSwagger.default.ui("/swagger", swagger);
-  // return AutoSwagger.default.scalar("/swagger"); to use Scalar instead
+  // return AutoSwagger.default.scalar("/swagger"); to use Scalar instead. If you want, you can pass proxy url as second argument here.
   // return AutoSwagger.default.rapidoc("/swagger", "view"); to use RapiDoc instead (pass "view" default, or "read" to change the render-style)
 });
 ```

--- a/src/autoswagger.ts
+++ b/src/autoswagger.ts
@@ -112,7 +112,7 @@ export class AutoSwagger {
     );
   }
 
-  scalar(url: string) {
+  scalar(url: string, proxyUrl: string = "https://proxy.scalar.com") {
     return `
       <!doctype html>
       <html>
@@ -130,7 +130,7 @@ export class AutoSwagger {
           <script
             id="api-reference"
             data-url="${url}"
-            data-proxy-url="https://proxy.scalar.com"></script>
+            data-proxy-url="${proxyUrl}"></script>
           <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
         </body>
       </html>


### PR DESCRIPTION
Super simple PR. Scalar uses it's proxy by default, and user should be able to disable (by passing empty string) or to change it.