### PR TITLE
feat: alway add enum to docs if comment declares it is an enum

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -706,6 +706,11 @@ export class ModelParser {
         format = "password";
       }
 
+      if (enums.length > 0) {
+        indicator = "type";
+        type = "string";
+      }
+
       if (type === "any") {
         indicator = "$ref";
         type = "#/components/schemas/Any";


### PR DESCRIPTION
In my project I have some TypeScript Enums that are used on a model. This gives a pointer error in the swagger docs as the autoswagger tries to resolve the enum to `/components/schema/<enum>` however the enums are not there.

This makes the comment leading, so that we dont have an ugly error in the swagger docs.