### PR TITLE
chore: add missing resource route default titles

### DIFF
--- a/src/autoswagger.ts
+++ b/src/autoswagger.ts
@@ -435,6 +435,16 @@ export class AutoSwagger {
             case "destroy":
               summary = "Delete " + tags[0].toLowerCase();
               break;
+     		case "store":
+              summary = "Create " + tags[0].toLowerCase();
+              break;
+			// frontend defaults
+            case "create":
+              summary = "Create (Frontend) " + tags[0].toLowerCase();
+              break;
+   			case "edit":
+              summary = "Update (Frontend) " + tags[0].toLowerCase();
+              break;
           }
         }
 


### PR DESCRIPTION
Adds the missing default titles for resource routes. These are currently not added by default, as can be seen below:

![image](https://github.com/user-attachments/assets/46bb6aa7-48a1-4662-b502-20a0e3196c09)
