### PR TITLE
feat: add spotlight elements docs ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Visit `http://localhost:3333/docs` to see AutoSwagger in action.
 - `ui(path, conf)`: get default swagger UI
 - `rapidoc(path, style)`: get rapidoc UI
 - `scalar(path)`: get scalar UI
+- `spotlight(path, theme)`: get spotlight elements UI
 - `jsonToYaml(json)`: can be used to convert `json()` back to yaml
 
 ---

--- a/src/autoswagger.ts
+++ b/src/autoswagger.ts
@@ -137,6 +137,29 @@ export class AutoSwagger {
     `;
   }
 
+  spotlight(url: string, theme: "light"|"dark" = "dark") {
+	return `
+      <!doctype html>
+      <html data-theme="${theme}">
+        <head>
+          <title>API Documentation - Spotlight</title>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+		  <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+          <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+        </head>
+        <body style="min-height:100vh">
+	      <elements-api
+		    style="display:block;height:100vh;width:100%;"
+		    apiDescriptionUrl=${url}
+		    router="hash"
+		    layout="sidebar"
+		  />
+        </body>
+      </html>
+    `;
+  }
+
   jsonToYaml(json: any) {
     return YAML.stringify(json);
   }


### PR DESCRIPTION
Adds support for spotlight ui: https://elements-demo.stoplight.io/

With support for both dark and light themes